### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -1,5 +1,8 @@
 name: Rust
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/duck-compiler/duckc/security/code-scanning/1](https://github.com/duck-compiler/duckc/security/code-scanning/1)

1. **General fix approach**:
   Add a `permissions` block to the workflow file to explicitly define the minimal required permissions for the job or the entire workflow.

2. **Specific fix for this codebase**:
   In the `.github/workflows/cargo-test.yml` file, add a permissions block to the root of the workflow to apply least-privilege permissions (e.g., `contents: read`).

3. **Details**:
   - The workflow only seems to read the repository contents (via `actions/checkout@v4`) and run tests (`cargo test`), so `contents: read` should suffice.
   - Add the permissions block at the beginning of the file, ensuring it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
