### PR TITLE
fix(windows): resolve PDB limit and stack overflow on dev builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [net]
 git-fetch-with-cli = true
+
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "link-arg=/DEBUG:NONE", "-C", "link-arg=/STACK:8388608"]


### PR DESCRIPTION
add msvc-specific linker flags to .cargo/config.toml:
- /DEBUG:NONE: prevets LNK1318 (E_PDB_LIMIT) caused by the combined debug info of tree-sitter, chumsky, etc. exceeding the PDB type table limit
- /STACK:8388608: raises the main thread stack to 8 MB to match the Linux default; the chumsky combinator chain overflows the Windows default of 1 MB at startup
